### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix local library hijacking in LD_LIBRARY_PATH

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Bash history default configuration logs sensitive data (secrets, tokens, passwords) entered in the command line if not filtered, which poses a risk of credential leakage.
 **Learning:** Development environments often leave shell history un-sanitized, potentially exposing temporary exported secrets or keys used in ad-hoc scripts.
 **Prevention:** Always implement `HISTCONTROL=ignoreboth` and `HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'` in bash dotfiles to prevent commands containing sensitive terms or prefixed with a space from being recorded.
+
+## 2024-05-18 - [Prevent Local Hijacking in Environment Variables]
+**Vulnerability:** Assigning `export LD_LIBRARY_PATH=/path:$LD_LIBRARY_PATH` when the variable is initially empty results in a trailing colon. This evaluates to the current working directory, introducing a local library hijacking vulnerability.
+**Learning:** Hardcoded `$PATH` or `$LD_LIBRARY_PATH` concatenations often fail to account for the empty state of these variables, silently exposing the system to directory traversal or hijacking risks.
+**Prevention:** Always use conditional parameter expansion (e.g., `${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}`) to append to path lists, ensuring colons are only added when the variable is non-empty.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -127,8 +127,8 @@ eval "$(starship init bash)"
 #                         ${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 #export LD_LIBRARY_PATH=/usr/lib/cuda/lib64:$LD_LIBRARY_PATH
 #export LD_LIBRARY_PATH=/usr/lib/cuda/include:$LD_LIBRARY_PATH
-export PATH=/usr/local/cuda/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+export PATH="/usr/local/cuda/bin${PATH:+:${PATH}}"
+export LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 . "$HOME/.cargo/env"
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unsafe path concatenation (`export LD_LIBRARY_PATH=/path:$LD_LIBRARY_PATH`) in `dot_bashrc`. If the variable is initially empty, this results in a trailing colon (e.g., `/path:`), which evaluates to the current working directory.
🎯 **Impact:** Local library hijacking. An attacker could place a malicious shared library in a directory the user visits, and it would be loaded by executables, leading to arbitrary code execution.
🔧 **Fix:** Used conditional parameter expansion (`${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}`) to only append the colon and previous contents if the variable is non-empty. Applied the same fix to `PATH` to prevent executable hijacking.
✅ **Verification:** Ran `bash -n dot_bashrc` to ensure syntax is correct. Also sourced the file in an environment with empty variables and confirmed no trailing colons were produced. Appended a learning entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17696456349856796355](https://jules.google.com/task/17696456349856796355) started by @partrita*

## Summary by Sourcery

Harden shell environment configuration to prevent local library and executable hijacking via PATH-like variables and document the associated security lesson.

Enhancements:
- Update PATH and LD_LIBRARY_PATH handling in dot_bashrc to avoid unsafe concatenation that exposes the current working directory for hijacking.

Documentation:
- Add a Sentinel learning entry describing the risks of naive PATH/LD_LIBRARY_PATH concatenation and the use of conditional parameter expansion as a mitigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA environment variable configuration to prevent potential security issues when system paths are not set.

* **Documentation**
  * Added documentation on environment variable path handling best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->