### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix local library hijacking vulnerability in PATH

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -136,7 +136,7 @@ export LD_LIBRARY_PATH="/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PA
 . "$HOME/.cargo/env"
 
 alias please="sudo"
-export PATH=$HOME/miniforge3/bin:$PATH
+export PATH="$HOME/miniforge3/bin${PATH:+:${PATH}}"
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
@@ -147,7 +147,7 @@ else
     if [ -f "/home/fkt/miniforge3/etc/profile.d/conda.sh" ]; then
         . "/home/fkt/miniforge3/etc/profile.d/conda.sh"
     else
-        export PATH="/home/fkt/miniforge3/bin:$PATH"
+        export PATH="/home/fkt/miniforge3/bin${PATH:+:${PATH}}"
     fi
 fi
 unset __conda_setup


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When appending paths to `PATH` (e.g. `export PATH=...:$PATH`), if `PATH` is initially empty, the resulting variable ends with a colon (`:`). In Unix systems, an empty path component (like `dir1::dir2` or a trailing colon) resolves to the current working directory (`.`). This creates a vulnerability where malicious executables or libraries in the current directory could be accidentally executed, introducing a local library hijacking risk.
🎯 Impact: If a user navigates to a directory containing a malicious executable with a common name (e.g., `ls` or `python`), they might inadvertently execute it if `PATH` ends with an empty component.
🔧 Fix: Updated `PATH` export statements in `dot_bashrc` to use conditional parameter expansion (`${PATH:+:${PATH}}`). This ensures that the colon is only appended if `PATH` is non-empty, preventing the trailing colon vulnerability.
✅ Verification: Ran `bash -n dot_bashrc` to ensure there are no syntax errors in the updated script. The behavior is functionally identical to the previous code when `PATH` is not empty, but secure when it is.

---
*PR created automatically by Jules for task [10117506959647648075](https://jules.google.com/task/10117506959647648075) started by @partrita*

## Summary by Sourcery

Enhancements:
- Update PATH export statements in the bash profile to use conditional parameter expansion so that separators are only added when PATH is non-empty.