### PR TITLE
🛡️ Sentinel: [security improvement] Enhance Bash audit logging and protect history configurations

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -8,8 +8,20 @@ HISTSIZE=1000
 HISTFILESIZE=2000
 
 # Security: Ignore history logging of commands starting with space or containing sensitive keywords
-HISTCONTROL=ignoreboth
-HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+if [[ -z "${HISTCONTROL+x}" || ! "$(declare -p HISTCONTROL 2>/dev/null)" =~ "declare -r" ]]; then
+    HISTCONTROL=ignoreboth
+    readonly HISTCONTROL
+fi
+
+if [[ -z "${HISTIGNORE+x}" || ! "$(declare -p HISTIGNORE 2>/dev/null)" =~ "declare -r" ]]; then
+    HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+    readonly HISTIGNORE
+fi
+
+# Security: Immediately append commands to history for accurate audit logging
+if [[ ! "$PROMPT_COMMAND" =~ "history -a" ]]; then
+    export PROMPT_COMMAND="history -a${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+fi
 
 # Security: Set default file permissions (readable/writable by user, readable by group, inaccessible by others)
 umask 027

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Assigning `export LD_LIBRARY_PATH=/path:$LD_LIBRARY_PATH` when the variable is initially empty results in a trailing colon. This evaluates to the current working directory, introducing a local library hijacking vulnerability.
 **Learning:** Hardcoded `$PATH` or `$LD_LIBRARY_PATH` concatenations often fail to account for the empty state of these variables, silently exposing the system to directory traversal or hijacking risks.
 **Prevention:** Always use conditional parameter expansion (e.g., `${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}`) to append to path lists, ensuring colons are only added when the variable is non-empty.
+
+## 2024-05-24 - [Ensure Immutable and Immediate Bash Audit Logging]
+**Vulnerability:** Bash by default only writes history to disk on exit. In the event of a terminal crash, or multiple parallel sessions, critical audit logs containing executed commands may be lost or overwritten. Furthermore, users or malicious scripts can dynamically unset history filtering variables (`HISTCONTROL`, `HISTIGNORE`), causing subsequent commands with sensitive data to be logged.
+**Learning:** Depending solely on `HISTIGNORE` without enforcing its immutability leaves a window where auditing can be disabled or tampered with by processes running in the shell session. Additionally, delaying history writes compromises the integrity of audit trails.
+**Prevention:** Configure `PROMPT_COMMAND` to immediately append to history (`history -a`), and enforce immutability on history security controls (`readonly HISTCONTROL HISTIGNORE`) within profile scripts.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -20,7 +20,20 @@ HISTSIZE=1000
 HISTFILESIZE=2000
 
 # Security: Ignore history logging of commands containing sensitive keywords
-HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+if [[ -z "${HISTIGNORE+x}" || ! "$(declare -p HISTIGNORE 2>/dev/null)" =~ "declare -r" ]]; then
+    HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+    readonly HISTIGNORE
+fi
+
+# Make HISTCONTROL readonly if not already
+if [[ ! "$(declare -p HISTCONTROL 2>/dev/null)" =~ "declare -r" ]]; then
+    readonly HISTCONTROL
+fi
+
+# Security: Immediately append commands to history for accurate audit logging
+if [[ ! "$PROMPT_COMMAND" =~ "history -a" ]]; then
+    export PROMPT_COMMAND="history -a${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+fi
 
 # Security: Set default file permissions (readable/writable by user, readable by group, inaccessible by others)
 umask 027


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bash history by default is only written on terminal exit, and variables controlling sensitive history filtering can be modified at runtime.
🎯 Impact: System crashes or multiple parallel terminals can cause critical command audit trails to be lost, and malicious processes can dynamically disable history filtering for subsequent commands.
🔧 Fix: Add `history -a` to `PROMPT_COMMAND` to flush commands immediately. Marked `HISTCONTROL` and `HISTIGNORE` as readonly to enforce immutability.
✅ Verification: `bash -n .bashrc` and `bash -n dot_bashrc`.

---
*PR created automatically by Jules for task [2546315607612760647](https://jules.google.com/task/2546315607612760647) started by @partrita*

## Summary by Sourcery

Strengthen Bash audit logging and history protection to improve command auditing reliability and prevent tampering with history filtering settings.

New Features:
- Ensure Bash immediately appends executed commands to the history file via PROMPT_COMMAND configuration.

Enhancements:
- Enforce immutability of Bash history filtering variables (HISTCONTROL and HISTIGNORE) when initializing shell environments.

Documentation:
- Document the Bash history auditing risks and mitigations in the Sentinel security notes, including immediate history flushing and readonly history controls.