### PR TITLE
🛡️ Sentinel: [security improvement] Prevent accidental secret commits

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,9 +15,11 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 umask 027
 
 # Security: Auto-logout idle sessions after 10 minutes
-TMOUT=600
-readonly TMOUT
-export TMOUT
+if [[ ! "$(declare -p TMOUT 2>/dev/null)" =~ "declare -r" ]]; then
+    TMOUT=600
+    readonly TMOUT
+    export TMOUT
+fi
 
 # 프롬프트 설정 (사용자명@호스트명:현재경로$)
 PS1='\[\e[32m\]\u@\h\[\e[00m\]:\[\e[34m\]\w\[\e[00m\]\$ '

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,29 @@ ENV/
 env.bak/
 venv.bak/
 
+# Security & Secrets (Prevent accidental commit of sensitive files)
+*.key
+*.pem
+*.cer
+*.cert
+*.p12
+*.pfx
+*id_rsa*
+*id_ed25519*
+*id_dsa*
+*id_ecdsa*
+*.history
+.bash_history
+.zsh_history
+.python_history
+.sqlite_history
+.mysql_history
+.psql_history
+.netrc
+.npmrc
+credentials.json
+client_secret.json
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Assigning `export LD_LIBRARY_PATH=/path:$LD_LIBRARY_PATH` when the variable is initially empty results in a trailing colon. This evaluates to the current working directory, introducing a local library hijacking vulnerability.
 **Learning:** Hardcoded `$PATH` or `$LD_LIBRARY_PATH` concatenations often fail to account for the empty state of these variables, silently exposing the system to directory traversal or hijacking risks.
 **Prevention:** Always use conditional parameter expansion (e.g., `${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}`) to append to path lists, ensuring colons are only added when the variable is non-empty.
+
+## 2024-06-25 - [Prevent Accidental Secret Commits in Dotfiles]
+**Vulnerability:** Dotfiles repositories are prone to accidentally committing local history files (e.g., `.bash_history`), SSH keys (e.g., `id_rsa`), certificates, and credential files if they are not explicitly ignored.
+**Learning:** Developers often track entire home directories or deeply nested `.config` folders, silently staging and pushing sensitive artifacts that get created alongside dotfiles.
+**Prevention:** Always maintain a comprehensive `Security & Secrets` exclusion section in `.gitignore` covering `*.key`, `*.pem`, `*.history`, and common credential files.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -26,9 +26,11 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 umask 027
 
 # Security: Auto-logout idle sessions after 10 minutes
-TMOUT=600
-readonly TMOUT
-export TMOUT
+if [[ ! "$(declare -p TMOUT 2>/dev/null)" =~ "declare -r" ]]; then
+    TMOUT=600
+    readonly TMOUT
+    export TMOUT
+fi
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing exclusions for sensitive local files in `.gitignore` which often leads to accidental secret leakage in dotfiles repositories. Also fixed the `readonly` assignment for `TMOUT` causing crashes on re-sourcing.
🎯 Impact: Could lead to the exposure of SSH keys, bash history, or credentials if a user accidentally adds un-ignored files to their dotfiles repository.
🔧 Fix: Appended a robust `Security & Secrets` ignore block to `.gitignore` covering `*.key`, `*.pem`, `*.history`, etc. Used a conditional `declare` check before setting `TMOUT` read-only.
✅ Verification: Review the `.gitignore` modifications and verify that bash syntax passes.

Included a journal entry in `.jules/sentinel.md` documenting this dotfiles repository vulnerability pattern.

---
*PR created automatically by Jules for task [9135570901577316022](https://jules.google.com/task/9135570901577316022) started by @partrita*

## Summary by Sourcery

Harden shell session security and document a recurring dotfiles secret-leak pattern while tightening ignore rules for sensitive files.

Enhancements:
- Guard TMOUT configuration so the auto-logout timeout can be safely re-sourced without causing errors.

Documentation:
- Extend the Sentinel journal with an entry describing how dotfiles repositories can accidentally commit shell histories, SSH keys, and other secrets, and how to prevent this with robust ignore rules.