### PR TITLE
🛡️ Sentinel: [security improvement] Fix readonly assignment error for TMOUT

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,9 +15,11 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 umask 027
 
 # Security: Auto-logout idle sessions after 10 minutes
-TMOUT=600
-readonly TMOUT
-export TMOUT
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then
+    TMOUT=600
+    readonly TMOUT
+    export TMOUT
+fi
 
 # 프롬프트 설정 (사용자명@호스트명:현재경로$)
 PS1='\[\e[32m\]\u@\h\[\e[00m\]:\[\e[34m\]\w\[\e[00m\]\$ '

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Assigning `export LD_LIBRARY_PATH=/path:$LD_LIBRARY_PATH` when the variable is initially empty results in a trailing colon. This evaluates to the current working directory, introducing a local library hijacking vulnerability.
 **Learning:** Hardcoded `$PATH` or `$LD_LIBRARY_PATH` concatenations often fail to account for the empty state of these variables, silently exposing the system to directory traversal or hijacking risks.
 **Prevention:** Always use conditional parameter expansion (e.g., `${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}`) to append to path lists, ensuring colons are only added when the variable is non-empty.
+
+## 2024-04-02 - [Prevent Re-sourcing Errors with Readonly Variables]
+**Vulnerability:** Assigning `readonly` to a variable like `TMOUT` without checking if it is already read-only causes the bash script to error and stop execution when re-sourced. Using naive checks like `readonly -p | grep -qw TMOUT` or `[[ ! "$(declare -p TMOUT)" =~ "declare -r" ]]` introduces a bypass because they match substrings in the entire output, including other variables' values (e.g. `declare -r MYVAR="TMOUT"` or `export TMOUT="declare -r"`).
+**Learning:** Checking for `readonly` status requires strict matching to avoid value spoofing and correctly handle alphabetical flag ordering.
+**Prevention:** Always use `readonly -p | grep -q "^declare -[^ =]*r[^ =]* VAR_NAME="` to strictly verify if a variable is marked as read-only by matching only the declaration part. Example: `if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then TMOUT=600; readonly TMOUT; export TMOUT; fi`.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -26,9 +26,11 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 umask 027
 
 # Security: Auto-logout idle sessions after 10 minutes
-TMOUT=600
-readonly TMOUT
-export TMOUT
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then
+    TMOUT=600
+    readonly TMOUT
+    export TMOUT
+fi
 
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.


### PR DESCRIPTION
🚨 Severity: LOW / Enhancement
💡 Vulnerability: When `TMOUT` is unconditionally set as `readonly` in bash configuration files, re-sourcing the file throws a "readonly variable" error. This can unexpectedly halt the script execution, preventing subsequent important configuration or security policies from being applied to the shell environment.
🎯 Impact: Incomplete environment initialization or skipped security settings upon shell reload.
🔧 Fix: Wrapped the `TMOUT` configuration block with an idempotent check: `if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then ...`. This safely ensures the auto-logout policy is enforced without triggering errors on subsequent source runs. The check uses strict regex to prevent value spoofing vulnerabilities.
✅ Verification: `bash -n .bashrc && bash -n dot_bashrc` succeeds, and `source .bashrc; source .bashrc` no longer prints `bash: TMOUT: readonly variable`.

---
*PR created automatically by Jules for task [7803668114655737992](https://jules.google.com/task/7803668114655737992) started by @partrita*

## Summary by Sourcery

Guard TMOUT auto-logout configuration with an idempotent readonly check to avoid errors on re-sourcing bash configs and document the underlying pattern and mitigation in Sentinel notes.

Bug Fixes:
- Prevent bash configuration from erroring and stopping execution when TMOUT is already readonly and the file is re-sourced.

Enhancements:
- Harden the TMOUT readonly detection using a strict grep pattern to avoid spoofing via other variables' values or flag ordering.
- Expand Sentinel documentation with guidance on safely checking readonly variables and avoiding naive pattern matches.