### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent tampering with bash audit logging

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,6 +15,13 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 export HISTTIMEFORMAT="%F %T "
 export PROMPT_COMMAND="history -a; ${PROMPT_COMMAND:-}"
 
+# Security: Prevent tampering with history variables by making them readonly
+for var in HISTFILE HISTSIZE HISTFILESIZE HISTIGNORE HISTCONTROL HISTTIMEFORMAT; do
+    if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* ${var}="; then
+        readonly ${var}
+    fi
+done
+
 # Security: Set default file permissions (readable/writable by user, readable by group, inaccessible by others)
 umask 027
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Assigning `readonly` to a variable like `TMOUT` without checking if it is already read-only causes the bash script to error and stop execution when re-sourced. Using naive checks like `readonly -p | grep -qw TMOUT` or `[[ ! "$(declare -p TMOUT)" =~ "declare -r" ]]` introduces a bypass because they match substrings in the entire output, including other variables' values (e.g. `declare -r MYVAR="TMOUT"` or `export TMOUT="declare -r"`).
 **Learning:** Checking for `readonly` status requires strict matching to avoid value spoofing and correctly handle alphabetical flag ordering.
 **Prevention:** Always use `readonly -p | grep -q "^declare -[^ =]*r[^ =]* VAR_NAME="` to strictly verify if a variable is marked as read-only by matching only the declaration part. Example: `if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then TMOUT=600; readonly TMOUT; export TMOUT; fi`.
+
+## 2024-04-06 - Enforce Audit Logging Integrity
+**Vulnerability:** Bash history variables (`HISTFILE`, `HISTSIZE`, `HISTIGNORE`, `HISTCONTROL`, `HISTTIMEFORMAT`) were mutable. A local attacker or malicious script could unset or modify them (e.g., `export HISTFILE=/dev/null`) to cover their tracks and bypass audit logging.
+**Learning:** Setting security-critical bash variables is insufficient if they can be easily overridden later in the session.
+**Prevention:** Apply `readonly` to history-related variables to ensure audit logging remains active and cannot be tampered with. Check if they are already readonly before applying to allow re-sourcing of the file without errors.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -26,6 +26,13 @@ HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
 export HISTTIMEFORMAT="%F %T "
 export PROMPT_COMMAND="history -a; ${PROMPT_COMMAND:-}"
 
+# Security: Prevent tampering with history variables by making them readonly
+for var in HISTFILE HISTSIZE HISTFILESIZE HISTIGNORE HISTCONTROL HISTTIMEFORMAT; do
+    if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* ${var}="; then
+        readonly ${var}
+    fi
+done
+
 # Security: Set default file permissions (readable/writable by user, readable by group, inaccessible by others)
 umask 027
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Bash history variables (`HISTFILE`, `HISTSIZE`, `HISTIGNORE`, `HISTCONTROL`, `HISTTIMEFORMAT`) were mutable. A local attacker or malicious script could unset or modify them (e.g., `export HISTFILE=/dev/null`) to cover their tracks and bypass audit logging.
🎯 Impact: Attackers or malware could silently execute commands without leaving an audit trail in `.bash_history`.
🔧 Fix: Applied `readonly` to history-related variables immediately after they are set in `.bashrc` and `dot_bashrc`, preventing any further mutation during the bash session.
✅ Verification: `readonly -p` now shows these variables are locked. Re-sourcing the rc files does not throw errors due to the existing safety checks.

---
*PR created automatically by Jules for task [913209488252035309](https://jules.google.com/task/913209488252035309) started by @partrita*

## Summary by Sourcery

Harden bash audit logging by making history-related variables read-only after configuration to prevent tampering during a session.

New Features:
- Enforce read-only status on bash history configuration variables in .bashrc and dot_bashrc to protect audit logs from modification.

Enhancements:
- Document the new bash history hardening measure in the Sentinel security notes, including vulnerability description, lessons learned, and prevention guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened shell security by enforcing read-only status on bash history configuration variables, preventing unintended modifications to audit settings.

* **Documentation**
  * Added security documentation outlining bash hardening best practices for protecting history variable integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->