### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix shell word splitting in package install script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Bash history variables (`HISTFILE`, `HISTSIZE`, `HISTIGNORE`, `HISTCONTROL`, `HISTTIMEFORMAT`) were mutable. A local attacker or malicious script could unset or modify them (e.g., `export HISTFILE=/dev/null`) to cover their tracks and bypass audit logging.
 **Learning:** Setting security-critical bash variables is insufficient if they can be easily overridden later in the session.
 **Prevention:** Apply `readonly` to history-related variables to ensure audit logging remains active and cannot be tampered with. Check if they are already readonly before applying to allow re-sourcing of the file without errors.
+
+## 2026-04-07 - [Bash Array Expansion Security]
+**Vulnerability:** Unquoted array expansions (e.g., `${ARRAY[@]}`) in shell scripts allow word splitting. This can lead to unintended package installations or command injection if an array contains strings with spaces.
+**Learning:** Even when arrays contain seemingly static data, they should be quoted defensively to prevent vulnerabilities during future modifications or if they eventually handle dynamic data.
+**Prevention:** Always use `"${ARRAY[@]}"` instead of `${ARRAY[@]}` to preserve elements as single words.

--- a/run_once_before_install-packages-darwin.sh.tmpl
+++ b/run_once_before_install-packages-darwin.sh.tmpl
@@ -28,12 +28,12 @@ printf '\nInitiating Homebrew update...\n'
 brew update
 
 printf '\nInstalling packages...\n'
-brew install ${PACKAGES[@]}
+brew install "${PACKAGES[@]}"
 
 printf '\n\nRemoving out of date packages...\n'
 brew cleanup
 
 printf '\n\nInstalling cask apps...\n'
-brew install --cask ${CASKS[@]}
+brew install --cask "${CASKS[@]}"
 
 {{ end -}}


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unquoted array expansions in shell scripts allow word splitting, risking unintended package installations or command injection if space-delimited strings are ever added to the array.
🎯 **Impact:** If modified in the future or dynamically supplied, items in `PACKAGES` or `CASKS` containing spaces would execute unintended arguments or shell operations. 
🔧 **Fix:** Wrapped `${PACKAGES[@]}` and `${CASKS[@]}` in double quotes (`"${...}"`) inside the installer script. Added a critical entry to the `.jules/sentinel.md` journal regarding array quoting.
✅ **Verification:** Ran `bash -n run_once_before_install-packages-darwin.sh.tmpl` to verify the syntax remains valid. Reviewer validated defensive improvement.

---
*PR created automatically by Jules for task [9008932771660893546](https://jules.google.com/task/9008932771660893546) started by @partrita*

## Summary by Sourcery

Harden the macOS Homebrew package installation script against shell word-splitting vulnerabilities and document the associated security practice in the Sentinel journal.

Bug Fixes:
- Prevent unintended word splitting and potential command injection by quoting package and cask array expansions in the Homebrew install script.

Documentation:
- Add a Sentinel journal entry describing risks of unquoted bash array expansions and the recommended quoting pattern for secure scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Homebrew installation commands in the macOS setup script with proper array expansion quoting to ensure correct argument parsing.

* **Documentation**
  * Added security documentation detailing bash array expansion vulnerabilities and best practices for safe quoting techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->