### PR TITLE
🛡️ Sentinel: [security improvement] Disable core dumps

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -32,6 +32,9 @@ if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then
     export TMOUT
 fi
 
+# Security: Disable core dumps to prevent sensitive data exposure from process memory on crash
+ulimit -S -c 0
+
 # 프롬프트 설정 (사용자명@호스트명:현재경로$)
 PS1='\[\e[32m\]\u@\h\[\e[00m\]:\[\e[34m\]\w\[\e[00m\]\$ '
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Unquoted array expansions (e.g., `${ARRAY[@]}`) in shell scripts allow word splitting. This can lead to unintended package installations or command injection if an array contains strings with spaces.
 **Learning:** Even when arrays contain seemingly static data, they should be quoted defensively to prevent vulnerabilities during future modifications or if they eventually handle dynamic data.
 **Prevention:** Always use `"${ARRAY[@]}"` instead of `${ARRAY[@]}` to preserve elements as single words.
+
+## 2024-04-08 - [Disable Core Dumps to Prevent Information Disclosure]
+**Vulnerability:** By default, Linux systems might be configured to generate core dumps when a program crashes. These files contain the memory state of the process at the time of the crash. If a process handling sensitive data (passwords, API keys, private keys, authentication tokens) crashes, this sensitive information can be written to disk in plain text within the core dump file, making it accessible to anyone with read access to the file.
+**Learning:** Development and general user environments often overlook process memory lifecycle. While debugging symbols and memory dumps are useful for developers, leaving them enabled globally in dotfiles poses a significant and unnecessary risk of post-crash credential exposure.
+**Prevention:** Disable core dump generation at the shell level in startup scripts (e.g., `.bashrc`, `dot_bashrc`) by adding `ulimit -S -c 0`. This acts as a defense-in-depth measure, ensuring that even if an application fails securely in code, its memory footprint isn't inadvertently leaked to the file system.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -43,6 +43,9 @@ if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* TMOUT="; then
     export TMOUT
 fi
 
+# Security: Disable core dumps to prevent sensitive data exposure from process memory on crash
+ulimit -S -c 0
+
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.
 shopt -s checkwinsize


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Disable core dumps

🚨 Severity: MEDIUM
💡 Vulnerability: Core dumps can inadvertently expose sensitive data such as API keys and plaintext passwords if a process crashes and memory is dumped to disk.
🎯 Impact: Anyone with read access to the core dump file could extract sensitive information.
🔧 Fix: Add `ulimit -S -c 0` to `.bashrc` and `dot_bashrc` to prevent core dumps from being generated. Also added journal entry.
✅ Verification: Tested via bash -n.

---
*PR created automatically by Jules for task [12096958325497125308](https://jules.google.com/task/12096958325497125308) started by @partrita*

## Summary by Sourcery

Disable generation of core dumps for interactive shells to reduce risk of sensitive data exposure from crashed processes.

Enhancements:
- Add a shell initialization setting in .bashrc and dot_bashrc to set a soft core file size limit of zero, preventing core dump creation.
- Extend the Sentinel security journal with an entry documenting the core dump information disclosure risk and the chosen mitigation.