### PR TITLE
🛡️ Sentinel: [security improvement] Require verification for bash history expansion

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -7,6 +7,12 @@
 HISTSIZE=1000
 HISTFILESIZE=2000
 
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# Security: Require verification before executing history expansion (e.g., !!)
+shopt -s histverify
+
 # Security: Ignore history logging of commands starting with space or containing sensitive keywords
 HISTCONTROL=ignoreboth
 HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Development tools often create environment files (like `.env.local`, `.env.development`, `.env.production`) to manage secrets locally. If a catch-all rule like `.env.*` is missing from `.gitignore`, developers may accidentally commit environment files containing sensitive local credentials, API keys, or access tokens to version control.
 **Learning:** Hardcoding specific environment file names (like `.env`) in `.gitignore` is insufficient, as various frameworks and developers create derivative files.
 **Prevention:** Always add a catch-all exclusion like `.env.*` (in addition to `.env`) to `.gitignore` under a security section to proactively prevent any local environment configuration variants from being tracked by git.
+
+## 2024-04-14 - [Bash History Expansion Security]
+**Vulnerability:** Bash history expansion (e.g., `!!`, `!$`) executes immediately by default. If a user mistypes or forgets the exact previous command context, they might unintentionally execute a destructive or sensitive command immediately without a chance to review it.
+**Learning:** Shell convenience features like history expansion prioritize speed over safety, which can lead to accidental system changes or credential exposure if the expanded command contains unexpected arguments.
+**Prevention:** Always enable `shopt -s histverify` in bash dotfiles. This forces bash to load the expanded command into the readline editing buffer for user review instead of executing it immediately.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -15,6 +15,9 @@ HISTCONTROL=ignoreboth
 # append to the history file, don't overwrite it
 shopt -s histappend
 
+# Security: Require verification before executing history expansion (e.g., !!)
+shopt -s histverify
+
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
 HISTSIZE=1000
 HISTFILESIZE=2000


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Bash history expansion (`!!`, `!$`) executes commands immediately by default, bypassing manual review.
🎯 **Impact**: Mistyped or misremembered history context could result in accidental execution of destructive commands (like `rm -rf`) or sensitive credentials. 
🔧 **Fix**: Added `shopt -s histverify` to `.bashrc` and `dot_bashrc` to ensure history expansions are loaded into the readline buffer for manual user verification instead of executing immediately. Added journal entry for tracking the learning.
✅ **Verification**: Start bash, type `echo 123`, then type `!!` and hit enter. The command `echo 123` will appear in the prompt ready to edit rather than instantly executing.

---
*PR created automatically by Jules for task [17825331455120754827](https://jules.google.com/task/17825331455120754827) started by @partrita*