### PR TITLE
🛡️ Sentinel: [Security Improvement] Prevent accidental Chezmoi secret leakage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ cython_debug/
 .bash_history
 credentials.json
 .env.*
+dot_bash_history
+dot_env
+dot_npmrc

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -52,3 +52,8 @@
 **Vulnerability:** Bash history expansion (e.g., `!!`, `!$`) executes immediately by default. If a user mistypes or forgets the exact previous command context, they might unintentionally execute a destructive or sensitive command immediately without a chance to review it.
 **Learning:** Shell convenience features like history expansion prioritize speed over safety, which can lead to accidental system changes or credential exposure if the expanded command contains unexpected arguments.
 **Prevention:** Always enable `shopt -s histverify` in bash dotfiles. This forces bash to load the expanded command into the readline editing buffer for user review instead of executing it immediately.
+
+## 2024-04-15 - [Prevent Accidental Leakage via Chezmoi File Prefixing]
+**Vulnerability:** Tools like Chezmoi use file prefixing (e.g., prepending `dot_` or `private_dot_` to file names) to represent hidden files in their source state. Standard `.gitignore` rules (like `.env*` or `.bash_history`) do not match these prefixed filenames. If a user manages environment files or shell histories via Chezmoi, these sensitive dotfiles are saved as `dot_env` or `dot_bash_history` in the Chezmoi directory and might be accidentally committed to a public dotfiles repository.
+**Learning:** Security exclusions in `.gitignore` must account for the specific naming conventions and path manipulations of the configuration management tools in use, not just standard system filenames.
+**Prevention:** Always append explicitly renamed secrets (like `dot_bash_history`, `dot_env`, `dot_npmrc`, `private_*`) to `.gitignore` when setting up a dotfiles repository managed by Chezmoi.


### PR DESCRIPTION
## Security Enhancement

### 💡 Vulnerability
When managing dotfiles with Chezmoi, sensitive files like `.bash_history`, `.env`, and `.npmrc` are stored in the source repository with `dot_` or `private_dot_` prefixes (e.g., `dot_env`, `dot_bash_history`). Standard `.gitignore` rules (like `.env*` or `.bash_history`) do not match these prefixed filenames. This creates a risk where users might accidentally commit sensitive user data, API keys, and shell histories to a public dotfiles repository.

### 🎯 Impact
Accidental credential leakage and exposure of private environment variables and command history if the repository is published or shared.

### 🔧 Fix
Added explicit exclusions for explicitly prefixed secret files (`dot_bash_history`, `dot_env`, `dot_npmrc`) to the `.gitignore` to prevent Chezmoi's renaming conventions from bypassing security controls. Documented this finding as a critical learning in the Sentinel journal (`.jules/sentinel.md`).

### ✅ Verification
Tested with `git check-ignore` and dummy files to verify that `dot_env`, `dot_bash_history`, and `dot_npmrc` are successfully ignored by git. Verified no bash configuration regressions via `bash -n`.

---
*PR created automatically by Jules for task [6834914010095564711](https://jules.google.com/task/6834914010095564711) started by @partrita*