### PR TITLE
🛡️ Sentinel: [security improvement] Prevent accidental leakage of private chezmoi files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ credentials.json
 dot_bash_history
 dot_env
 dot_npmrc
+private_*


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential leakage of sensitive private data (e.g. `private_dot_ssh` or `private_credentials.json`) which are tracked by Chezmoi due to `private_*` prefixing, which ignores traditional `.gitignore` policies. 
🎯 Impact: Could result in accidental exposure of highly sensitive files to the version control, particularly if users have localized `private_` secrets within the repository without knowing it.
🔧 Fix: Appended `private_*` to the `# Security and secrets` section in `.gitignore` to explicitly ensure Chezmoi private files and other sensitive keys are not tracked.
✅ Verification: Ensure the `.gitignore` contains `private_*`.

---
*PR created automatically by Jules for task [16250650993699630210](https://jules.google.com/task/16250650993699630210) started by @partrita*