### PR TITLE
🛡️ Sentinel: [HIGH] Fix bash history logging bypass

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -4,6 +4,11 @@
 
 # 셸 옵션 설정
 # 히스토리 크기 설정
+
+# Security: Explicitly define HISTFILE to prevent environment override (e.g., HISTFILE=/dev/null bash)
+export HISTFILE="${HOME}/.bash_history"
+touch "$HISTFILE" 2>/dev/null || true
+chmod 600 "$HISTFILE" 2>/dev/null || true
 HISTSIZE=1000
 HISTFILESIZE=2000
 

--- a/.bashrc
+++ b/.bashrc
@@ -6,9 +6,11 @@
 # 히스토리 크기 설정
 
 # Security: Explicitly define HISTFILE to prevent environment override (e.g., HISTFILE=/dev/null bash)
-export HISTFILE="${HOME}/.bash_history"
-touch "$HISTFILE" 2>/dev/null || true
-chmod 600 "$HISTFILE" 2>/dev/null || true
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTFILE="; then
+    export HISTFILE="${HOME}/.bash_history"
+    touch "$HISTFILE" 2>/dev/null || true
+    chmod 600 "$HISTFILE" 2>/dev/null || true
+fi
 HISTSIZE=1000
 HISTFILESIZE=2000
 

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -66,3 +66,8 @@
 **Vulnerability:** Vim and Neovim allow embedding editor commands directly within a text file using a feature called "modelines". If a user opens a maliciously crafted file, these embedded commands are automatically executed. Historically, this feature has been a vector for arbitrary code execution vulnerabilities, allowing attackers to compromise the system simply by having the user view a file.
 **Learning:** Convenience features that automatically execute embedded instructions upon file access inherently increase the attack surface and pose significant risks, especially when reviewing code or logs from untrusted sources.
 **Prevention:** Always explicitly disable modeline support in Vim (`set nomodeline` and `set modelines=0` in `.vimrc`) and Neovim (`vim.opt.modeline = false` and `vim.opt.modelines = 0` in `init.lua`) configurations to prevent any unintended code execution when opening files.
+
+## 2024-04-20 - Prevent Bash Audit Logging Bypass via Environment Override
+**Vulnerability:** Bash history variables like `HISTFILE` were made readonly without being explicitly initialized first. An attacker could run `HISTFILE=/dev/null bash`, causing the shell to inherit the malicious value and lock it as readonly, effectively disabling audit logging for that session.
+**Learning:** Making security-critical variables readonly is insufficient if their initial values are inherited from an untrusted environment.
+**Prevention:** Always explicitly define security-critical variables like `HISTFILE` (e.g., `HISTFILE="${HOME}/.bash_history"`) before applying the `readonly` attribute to ensure they cannot be spoofed via environment variables.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -19,6 +19,10 @@ shopt -s histappend
 shopt -s histverify
 
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+# Security: Explicitly define HISTFILE to prevent environment override (e.g., HISTFILE=/dev/null bash)
+export HISTFILE="${HOME}/.bash_history"
+touch "$HISTFILE" 2>/dev/null || true
+chmod 600 "$HISTFILE" 2>/dev/null || true
 HISTSIZE=1000
 HISTFILESIZE=2000
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Bash history variables like `HISTFILE` were made readonly without being explicitly initialized first. This allowed an attacker to bypass audit logging by running `HISTFILE=/dev/null bash`, causing the shell to inherit the malicious value and lock it as readonly. Additionally, the history file permissions were not explicitly secured.
🎯 Impact: Attackers could execute commands without being logged in the bash history, bypassing audit trails. Furthermore, history files could potentially inherit insecure default permissions, allowing unauthorized local users to read sensitive commands.
🔧 Fix: Explicitly defined `HISTFILE="${HOME}/.bash_history"` before applying the `readonly` attribute in both `.bashrc` and `dot_bashrc` to prevent environment variable spoofing. Also added `touch` and `chmod 600` commands (with safe fallbacks `|| true`) to enforce secure permissions on the history file. Added an entry to the Sentinel journal detailing the vulnerability and prevention.
✅ Verification: Ran `bash -n .bashrc` and `bash -n dot_bashrc` to ensure syntax is valid.

---
*PR created automatically by Jules for task [17480236771424232616](https://jules.google.com/task/17480236771424232616) started by @partrita*