### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix readonly variable errors on script re-source

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -11,8 +11,12 @@ if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTFILE="; then
     touch "$HISTFILE" 2>/dev/null || true
     chmod 600 "$HISTFILE" 2>/dev/null || true
 fi
-HISTSIZE=1000
-HISTFILESIZE=2000
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTSIZE="; then
+    HISTSIZE=1000
+fi
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTFILESIZE="; then
+    HISTFILESIZE=2000
+fi
 
 # append to the history file, don't overwrite it
 shopt -s histappend
@@ -21,11 +25,17 @@ shopt -s histappend
 shopt -s histverify
 
 # Security: Ignore history logging of commands starting with space or containing sensitive keywords
-HISTCONTROL=ignoreboth
-HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTCONTROL="; then
+    HISTCONTROL=ignoreboth
+fi
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTIGNORE="; then
+    HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+fi
 
 # Security: Add timestamps to history for audit logging and flush immediately
-export HISTTIMEFORMAT="%F %T "
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTTIMEFORMAT="; then
+    export HISTTIMEFORMAT="%F %T "
+fi
 export PROMPT_COMMAND="history -a; ${PROMPT_COMMAND:-}"
 
 # Security: Prevent tampering with history variables by making them readonly

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -71,3 +71,8 @@
 **Vulnerability:** Bash history variables like `HISTFILE` were made readonly without being explicitly initialized first. An attacker could run `HISTFILE=/dev/null bash`, causing the shell to inherit the malicious value and lock it as readonly, effectively disabling audit logging for that session.
 **Learning:** Making security-critical variables readonly is insufficient if their initial values are inherited from an untrusted environment.
 **Prevention:** Always explicitly define security-critical variables like `HISTFILE` (e.g., `HISTFILE="${HOME}/.bash_history"`) before applying the `readonly` attribute to ensure they cannot be spoofed via environment variables.
+
+## 2024-05-18 - Prevent script crashes from readonly security variables
+**Vulnerability:** Bash profiles (`.bashrc`, `dot_bashrc`) crashed with "readonly variable" errors when re-sourced because history security variables (`HISTSIZE`, `HISTCONTROL`, etc.) were assigned values and then made readonly. Re-running the script attempts to reassign the readonly variables, breaking shell initialization.
+**Learning:** Security hardening must not break usability. Making variables readonly is correct, but the assignment itself must first check if the variable is already readonly.
+**Prevention:** Wrap variable assignments in a readonly check (`if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* VAR_NAME="; then VAR_NAME=value; fi`) to ensure idempotent execution.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -10,7 +10,9 @@ esac
 
 # don't put duplicate lines or lines starting with space in the history.
 # See bash(1) for more options
-HISTCONTROL=ignoreboth
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTCONTROL="; then
+    HISTCONTROL=ignoreboth
+fi
 
 # append to the history file, don't overwrite it
 shopt -s histappend
@@ -20,17 +22,27 @@ shopt -s histverify
 
 # for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
 # Security: Explicitly define HISTFILE to prevent environment override (e.g., HISTFILE=/dev/null bash)
-export HISTFILE="${HOME}/.bash_history"
-touch "$HISTFILE" 2>/dev/null || true
-chmod 600 "$HISTFILE" 2>/dev/null || true
-HISTSIZE=1000
-HISTFILESIZE=2000
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTFILE="; then
+    export HISTFILE="${HOME}/.bash_history"
+    touch "$HISTFILE" 2>/dev/null || true
+    chmod 600 "$HISTFILE" 2>/dev/null || true
+fi
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTSIZE="; then
+    HISTSIZE=1000
+fi
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTFILESIZE="; then
+    HISTFILESIZE=2000
+fi
 
 # Security: Ignore history logging of commands containing sensitive keywords
-HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTIGNORE="; then
+    HISTIGNORE='*password*:*secret*:*key*:*token*:*sudo -S*'
+fi
 
 # Security: Add timestamps to history for audit logging and flush immediately
-export HISTTIMEFORMAT="%F %T "
+if ! readonly -p | grep -q "^declare -[^ =]*r[^ =]* HISTTIMEFORMAT="; then
+    export HISTTIMEFORMAT="%F %T "
+fi
 export PROMPT_COMMAND="history -a; ${PROMPT_COMMAND:-}"
 
 # Security: Prevent tampering with history variables by making them readonly


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Re-sourcing bash profiles (`.bashrc` / `dot_bashrc`) caused "readonly variable" errors due to reassigning history variables that were previously marked readonly. This caused shell initialization issues and error output, potentially leading users to remove the security hardening altogether.
🎯 Impact: Usability breakdown for users updating their dotfiles and re-sourcing them.
🔧 Fix: Wrapped all security history variable assignments (`HISTSIZE`, `HISTCONTROL`, `HISTIGNORE`, `HISTTIMEFORMAT`) with idempotent `readonly -p` checks to ensure they are only assigned if they are not already locked.
✅ Verification: Ran `bash -c 'source .bashrc; source .bashrc'` and observed no readonly variable errors. Tested `.bashrc` and `dot_bashrc` syntax via `bash -n`. Updated `.jules/sentinel.md` with the learning.

---
*PR created automatically by Jules for task [123881232374239065](https://jules.google.com/task/123881232374239065) started by @partrita*