### PR TITLE
🛡️ Sentinel: [security improvement] Add interactive aliases for rm, cp, and mv

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -75,6 +75,11 @@ alias ll='ls -alF' # 자세히 보기
 alias la='ls -A'   # 숨김 파일 포함
 alias l='ls -CF'   # 컬러 출력
 
+# Security: Require confirmation before overwriting or deleting files
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
 # Jupyter Notebook 기본 설정
 # 자동완성 기능 활성화 (Tab 키)
 # (Jupyter 자체 설정 파일에서 주로 관리하지만, 편의상 bashrc에 추가적인 설정을 넣을 수도 있습니다.)

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -86,3 +86,8 @@
 **Vulnerability:** By default, the `less` pager writes search history to `~/.lesshst`. If a user views files containing sensitive data (e.g., passwords, API keys, tokens) and searches for them using `less`, these sensitive terms can be inadvertently written to disk in plain text.
 **Learning:** Command-line tools like `less` maintain their own history files that bypass Bash audit controls and `.bash_history` restrictions, requiring tool-specific environment variables to secure.
 **Prevention:** Export `LESSHISTFILE="-"` in shell configuration files (`.bashrc`, `dot_bashrc`) to completely disable the `less` pager from writing search history to disk.
+
+## 2024-05-22 - [Prevent Accidental File Deletion/Overwrite via Interactive Aliases]
+**Vulnerability:** In Bash, default commands like `rm`, `cp`, and `mv` operate silently and will irreversibly delete or overwrite files without warning. In an interactive session, a typo (e.g., `rm * .txt` instead of `rm *.txt`) can result in catastrophic data loss.
+**Learning:** Shell defaults are designed for scripting efficiency and assume the user knows exactly what they are doing. This lack of guardrails is dangerous for interactive human use.
+**Prevention:** Always define interactive aliases (`alias rm='rm -i'`, `alias cp='cp -i'`, `alias mv='mv -i'`) in shell configuration files (`.bashrc`, `dot_bashrc`). This forces the shell to prompt for confirmation before performing destructive actions, providing a crucial safety net for human error.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -147,6 +147,11 @@ alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
+# Security: Require confirmation before overwriting or deleting files
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
 # Add an "alert" alias for long running commands.  Use like so:
 #   sleep 10; alert
 alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Default commands like `rm`, `cp`, and `mv` lack safety guardrails in interactive sessions, allowing typos to cause irreversible data loss.
🎯 Impact: Accidental deletion or overwriting of important files.
🔧 Fix: Configured `alias rm='rm -i'`, `alias cp='cp -i'`, and `alias mv='mv -i'` in `.bashrc` and `dot_bashrc` to prompt for user confirmation before destructive actions.
✅ Verification: Tested `.bashrc` and `dot_bashrc` syntax with `bash -n`. The aliases are correctly sourced in non-login interactive shells.

---
*PR created automatically by Jules for task [6549232173163676967](https://jules.google.com/task/6549232173163676967) started by @partrita*